### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SettingsAppAccess
 
 Installation
 ---
-**SettingsAppAccess** is available through **[cocoapods](http://cocoapods.org)**, to install simple add the following line to your `PodFile`:
+**SettingsAppAccess** is available through **[CocoaPods](http://cocoapods.org)**, to install simple add the following line to your `PodFile`:
 
 ``` ruby
   pod "SettingsAppAccess"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SettingsAppAccess
 
 Installation
 ---
-**SettingsAppAccess** is available through **[CocoaPods](http://cocoapods.org)**, to install simple add the following line to your `PodFile`:
+**SettingsAppAccess** is available through **[CocoaPods](http://cocoapods.org)**, to install simple add the following line to your `Podfile`:
 
 ``` ruby
   pod "SettingsAppAccess"


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
